### PR TITLE
update mapping lesson to run warm-up and *not* terminate

### DIFF
--- a/rob_map/tut.rst
+++ b/rob_map/tut.rst
@@ -334,4 +334,12 @@ From the number of alignments, you can see that the multimapping rate of RapMap 
 	 There are 36,968,390 reads in the original file.
 
 
-**TERMINATE YOUR INSTANCE!!!**
+"""""""""""""""""""""""""""""""
+Preparing for tomorrow's lesson
+"""""""""""""""""""""""""""""""
+
+Tomorrow, rather than just dealing with a single pair of read files, we'll quantify *all* of our samples using the ultra-fast quantification tool, Salmon.  In order to prepare your Amazon instance, you'll have to "warm up" the volume with the data.  To do this, you'll have to run the following command, and let it execute until it completes::
+  
+  >sudo fio --filename=/dev/xvdf --rw=randread --bs=128k --iodepth=32 --ioengine=libaio --direct=1 --name=volume-initialize
+
+This will tell the instance to "touch" all of the blocks on this volume, which will make sure they are physically present, and not just "accessible".  This command make take 1.5 - 2 hours to complete.  Once this is done, we will **stop** the instance.  *Note:*  **Do not terminate your instance, stop it instead**, otherwise you'll loose all of the work that was just done to warm the volume.

--- a/rob_map/tut.rst
+++ b/rob_map/tut.rst
@@ -150,7 +150,10 @@ We'll put all of these in a folder called ``ref``, and, since they're fairly sma
   > gunzip *.gz
   > cd ..
   
-Great; now, we're ready to grab our aligner and align some reads!
+Great; now, we're ready to grab our aligner and align some reads ... almost!  For a reason that I'd be happy to explain if anyone is actually curious, we have to "warm up" the file's we'll be aligning.  We can do this as follows::
+
+  > wc -l <(gunzip -c /mnt/reads/ORE_sdE3_r1_GTGGCC_L004_R1_001.fastq.gz)
+  > wc -l <(gunzip -c /mnt/reads/ORE_sdE3_r1_GTGGCC_L004_R2_001.fastq.gz)
 
 Using STAR
 --------------

--- a/rob_map/tut.rst
+++ b/rob_map/tut.rst
@@ -155,6 +155,8 @@ Great; now, we're ready to grab our aligner and align some reads ... almost!  Fo
   > wc -l <(gunzip -c /mnt/reads/ORE_sdE3_r1_GTGGCC_L004_R1_001.fastq.gz)
   > wc -l <(gunzip -c /mnt/reads/ORE_sdE3_r1_GTGGCC_L004_R2_001.fastq.gz)
 
+Now, we're *actually* ready to do our alignment / mapping.
+
 Using STAR
 --------------
 

--- a/rob_quant/tut.rst
+++ b/rob_quant/tut.rst
@@ -33,11 +33,7 @@ First, install the "build tools" (compilers etc. that may be needed)::
 Mounting the reads
 ------------------
 
-We have prepared (thanks; `@monsterbashseq! <https://ljcohen.github.io/>`_) an Amazon volume from which you can load the reads directly.  When we created our AWS instance, we attached the volume with the reads to ``/dev/xvdf``.  We have to *mount* this device.  First, we'll create a place to mount it::
-
-  > sudo mkdir -p /mnt/reads
-
-Now, we actualy mount the device at the mount point::
+We have prepared (thanks; `@monsterbashseq! <https://ljcohen.github.io/>`_) an Amazon volume from which you can load the reads directly.  When we created our AWS instance, we attached the volume with the reads to ``/dev/xvdf``.  We have to *mount* this device.  Since we're using the volume from yesterday, a place for the volume `/mnt/reads` already exists. Here, we just mount the device at the mount point::
 
   >sudo mount /dev/xvdf /mnt/reads
 


### PR DESCRIPTION
Add the command to warm the volume to the end of the mapping lesson.  Remind the students to stop, not terminate, their instance at the end of the lesson.
