### PR TITLE
Keep the header of the vcf file

### DIFF
--- a/variant-calling.md
+++ b/variant-calling.md
@@ -131,14 +131,14 @@ thinks are there. What's in it?
 The [official VCF specification](https://samtools.github.io/hts-specs/VCFv4.1.pdf) is a great read...if you're suffering from insomnia.
 Let's skip this and just take a quick look at the file.
 
-1. Look at the non-commented lines:
+1. Look at the non-commented lines along with the header:
 
-        grep -v ^# variants.vcf
+        grep -v ^## variants.vcf
 
    The first five columns: `CHROM  POS     ID      REF     ALT`.
    It's a little easier to see if you run
 
-        grep -v ^# variants.vcf | less -S
+        grep -v ^## variants.vcf | less -S
 
     Use your left and right arrows to scroll, and 'q' to quit.
 


### PR DESCRIPTION
Removing all the commented lines except the header to make it easy to understand the columns

### Things to check off before merging:

- [x] Files are listed in `toc.rst` so they will show up on the side bar.
- [x] The tutorial assumes we're starting from a blank `Ubuntu 16.04` image on Jetstream.
