### PR TITLE
fix toc name so R Th will link

### DIFF
--- a/toc.rst
+++ b/toc.rst
@@ -21,7 +21,7 @@ Table of Contents
    variant-calling
    introduction-to-automation
 
-   introduction-to-r-and-dataframes
+   introduction-to-R-and-dataframes
    counting
    
    genome-assembly


### PR DESCRIPTION
Noticed that the toc link was broken for the R thursday tutorial. Capitalization issue -- should be fixed now!

### Things to check off before merging:

- [ ] Files are listed in `toc.rst` so they will show up on the side bar.
- [ ] The tutorial assumes we're starting from a blank `Ubuntu 16.04` image on Jetstream.
