### PR TITLE
A few fixes to the Chip-Seq lesson

### DIFF
--- a/chip-seq.md
+++ b/chip-seq.md
@@ -49,7 +49,7 @@ Let do the installation process:
 wget https://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.2/bowtie2-2.3.2-linux-x86_64.zip
 unzip bowtie2-2.3.2-linux-x86_64.zip
 
-echo 'export PATH=$PATH:~/ChIP-seq/bowtie2-2.3.2' >> ~/.bashrc
+echo 'export PATH=$PATH:~/bowtie2-2.3.2' >> ~/.bashrc
 source ~/.bashrc
 ```
 

--- a/chip-seq.md
+++ b/chip-seq.md
@@ -99,6 +99,7 @@ chmod +x bedGraphToBigWig
 The easiest way to install MACS2 is through PyPI system:
 
 ```
+pip install numpy
 pip install MACS2
 ```
 

--- a/chip-seq.md
+++ b/chip-seq.md
@@ -198,7 +198,7 @@ In order to use tview, we need first to sort the `BAM` file by position in the g
 Use the following commands:
 
 ```
-samtools sort Oct4.bam Oct4.sorted
+samtools sort Oct4.bam -o Oct4.sorted.bam
 
 samtools index Oct4.sorted.bam
 ```
@@ -259,7 +259,7 @@ bowtie2 -x bowtie_index/mm10 -U gfp.fastq -S gfp.sam
 
 samtools view -bSo gfp.bam gfp.sam
 
-samtools sort gfp.bam gfp.sorted
+samtools sort gfp.bam -o gfp.sorted.bam
 
 samtools index gfp.sorted.bam
 

--- a/chip-seq.md
+++ b/chip-seq.md
@@ -198,7 +198,7 @@ In order to use tview, we need first to sort the `BAM` file by position in the g
 Use the following commands:
 
 ```
-samtools sort Oct4.bam -o Oct4.sorted.bam
+samtools sort Oct4.bam Oct4.sorted
 
 samtools index Oct4.sorted.bam
 ```
@@ -259,7 +259,7 @@ bowtie2 -x bowtie_index/mm10 -U gfp.fastq -S gfp.sam
 
 samtools view -bSo gfp.bam gfp.sam
 
-samtools sort gfp.bam -o gfp.sorted.bam
+samtools sort gfp.bam gfp.sorted
 
 samtools index gfp.sorted.bam
 

--- a/chip-seq.md
+++ b/chip-seq.md
@@ -197,7 +197,7 @@ In order to use tview, we need first to sort the `BAM` file by position in the g
 Use the following commands:
 
 ```
-samtools sort Oct4.bam Oct4.sorted
+samtools sort Oct4.bam -o Oct4.sorted.bam
 
 samtools index Oct4.sorted.bam
 ```
@@ -258,7 +258,7 @@ bowtie2 -x bowtie_index/mm10 -U gfp.fastq -S gfp.sam
 
 samtools view -bSo gfp.bam gfp.sam
 
-samtools sort gfp.bam gfp.sorted
+samtools sort gfp.bam -o gfp.sorted.bam
 
 samtools index gfp.sorted.bam
 


### PR DESCRIPTION
We install `bowtie2` before moving to the `ChIP-seq` dir. Modified the path to reflect that.

Also fixed the `samtools sort` commands