### PR TITLE
add numpy install to CHIPseq

### DIFF
--- a/chip-seq.md
+++ b/chip-seq.md
@@ -99,6 +99,7 @@ chmod +x bedGraphToBigWig
 The easiest way to install MACS2 is through PyPI system:
 
 ```
+pip install numpy
 pip install MACS2
 ```
 


### PR DESCRIPTION
(MACS2 dependency)

(Please put a direct link to the updated tutorial(s) on the PR branch here,
so we can look at them while reviewing!)

### Things to check off before merging:

- [ ] Files are listed in `toc.rst` so they will show up on the side bar.
- [ ] Files are listed in `index.rst` appropriately
- [ ] The tutorial assumes we're starting from a blank `Ubuntu 16.04` image on Jetstream.
