### PR TITLE
Fixed typo

### DIFF
--- a/rna-seq.md
+++ b/rna-seq.md
@@ -6,7 +6,7 @@ Learning objectives:
   
 * Learn mapping and differential gene expression analysis
 
-* Interpret rna-seq analysis
+* Interpret rna-seq analysis results
 
 ## Boot up a Jetstream
 


### PR DESCRIPTION
- [x] tutorial resets working directory at beginning with a `cd ~/``
- [x] tutorial contains relevant `conda install -y` commands at the beginning
- [x] tutorial links to previous tutorial (at top) and next tutorial (at bottom)
- [x] tutorial has learning objectives at top


