### PR TITLE
Added a stats analysis of assembly

### DIFF
--- a/transcriptome-assembly.md
+++ b/transcriptome-assembly.md
@@ -20,7 +20,7 @@ Trinity, developed at the [Broad Institute](http://www.broadinstitute.org/) and 
 
 [Boot an m1.medium Jetstream instance](jetstream/boot.md) and log in.
 
-## Install the MEGAHIT assembler
+## Install the TRINITY assembler
 
 The [Trinity assembler](https://www.ncbi.nlm.nih.gov/pubmed/21572440) can also install it through `conda`:
 

--- a/transcriptome-assembly.md
+++ b/transcriptome-assembly.md
@@ -120,3 +120,50 @@ head yeast-transcriptome-assembly.fa
 ```
     
 It's RNA! Yay!
+
+Let's capture also some statistics of the Trinity assembly. Trinity provides a handy tool to do exactly that:
+
+```
+TrinityStats.pl yeast-transcriptome-assembly.fa
+```
+
+The output should look something like the following:
+
+```
+################################
+## Counts of transcripts, etc.
+################################
+Total trinity 'genes':  3305
+Total trinity transcripts:      3322
+Percent GC: 42.05
+
+########################################
+Stats based on ALL transcript contigs:
+########################################
+
+        Contig N10: 1355
+        Contig N20: 1016
+        Contig N30: 781
+        Contig N40: 617
+        Contig N50: 502
+
+        Median contig length: 319
+        Average contig: 441.65
+        Total assembled bases: 1467173
+
+#####################################################
+## Stats based on ONLY LONGEST ISOFORM per 'GENE':
+#####################################################
+
+        Contig N10: 1358
+        Contig N20: 1016
+        Contig N30: 781
+        Contig N40: 617
+        Contig N50: 500
+
+        Median contig length: 319
+        Average contig: 440.93
+        Total assembled bases: 1457279
+```
+
+This is a set of summary stats about your assembly. Are they good? Bad? How would you know?


### PR DESCRIPTION
- [x] tutorial resets working directory at beginning with a `cd ~/``
- [x] tutorial contains relevant `conda install -y` commands at the beginning
- [x] tutorial links to previous tutorial (at top) and next tutorial (at bottom)
- [x] tutorial has learning objectives at top


