### PR TITLE
Removed the link in the end of the lesson

### DIFF
--- a/running-command-line-blast.md
+++ b/running-command-line-blast.md
@@ -172,5 +172,3 @@ You can open the file with `less mm-second.x.zebrafish.tsv` to see how the file 
 
 See [this link](http://www.metagenomics.wiki/tools/blast/blastn-output-format-6) for a description of the possible BLAST output formats.
 
-## [NEXT - Visualizing BLAST score distributions in RStudio](visualizing-blast-scores-with-RStudio.html)
-


### PR DESCRIPTION
... because readthedocs provide the links already based on the ToC.

- [x] tutorial resets working directory at beginning with a `cd ~/``
- [x] tutorial contains relevant `conda install -y` commands at the beginning
- [ ] tutorial links to previous tutorial (at top) and next tutorial (at bottom)
- [x] tutorial has learning objectives at top


