### PR TITLE
Fix bedtools command - was using wrong input file

### DIFF
--- a/chip-seq.md
+++ b/chip-seq.md
@@ -385,7 +385,7 @@ head mm10_refgene.bed
 Which peaks overlap with the promoter regions? To do this, we will use [`bedtools intersect`](http://bedtools.readthedocs.io/en/latest/content/tools/intersect.html):
 
 ```bash
-bedtools intersect -a Oct_peaks.bed -b mm10_refgene.bed -wa -wb > Oct4_peaks_overlap_promoter.txt
+bedtools intersect -a Oct_peaks.bed -b mm10genes.5kb.promoters.bed -wa -wb > Oct4_peaks_overlap_promoter.txt
 ```
 which genes?
 


### PR DESCRIPTION
(pointed out by Tristian during an afternoon session in bears room)

PR author:
- [x] pull request is ready for review & merge

Things to check: (N/A)

- [] ~tutorial resets working directory at beginning with a `cd ~/``~
- [] ~tutorial contains relevant `conda install -y` commands at the beginning~
- [] ~tutorial links to previous tutorial (at top) and next tutorial (at bottom)~
- [] ~tutorial has learning objectives at top~


