### PR TITLE
fix download link, change df for pheatmap

### DIFF
--- a/diff-ex-and-viz.md
+++ b/diff-ex-and-viz.md
@@ -63,7 +63,7 @@ function to read this file into R as a dataframe directly from a url.
 
 ```
 # read in the file from url
-samples <- read_csv("https://osf.io/a75zm/download")
+samples <- read_csv("https://osf.io/cxp2w/download")
 # look at the first 6 lines
 head(samples)
 ```
@@ -294,10 +294,9 @@ do this.
 
 ```
 annot_col <- samples %>%
+  column_to_rownames('sample') %>%
   select(condition) %>%
   as.data.frame()
-
-as.factor(annot_col$condition)
 
 head(annot_col)
 ```


### PR DESCRIPTION
The download link for samples pointed to the wrong file. 
`annot_col` needed to have rownames set. 

PR author:
- [x] pull request is ready for review & merge

Things to check:

- [x] tutorial resets working directory at beginning with a `cd ~/``
- [x] tutorial has learning objectives at top

@katffowler ready for review!

