### PR TITLE
Update salmon-quant.md

### DIFF
--- a/salmon-quant.md
+++ b/salmon-quant.md
@@ -20,7 +20,7 @@ cd quality
 curl -L https://osf.io/wfz34/download -o ERR458493.qc.fq.gz
 curl -L https://osf.io/jxh4d/download -o ERR458494.qc.fq.gz
 curl -L https://osf.io/zx7n3/download -o ERR458495.qc.fq.gz
-curl -L https://osf.io/96mrj/download -o ERR458500.qc.fq.gz.
+curl -L https://osf.io/96mrj/download -o ERR458500.qc.fq.gz
 curl -L https://osf.io/wc8yn/download -o ERR458501.qc.fq.gz
 curl -L https://osf.io/sdtz3/download -o ERR458502.qc.fq.gz
 ```


### PR DESCRIPTION
Removed a '.' that was at the end of the output of downloading the trimmed data for ERR458500.qc.fq.gz

