### PR TITLE
Correct scp command to download fastqc output

### DIFF
--- a/quality-and-trimming.md
+++ b/quality-and-trimming.md
@@ -258,7 +258,7 @@ mkdir -p ~/Desktop/fastqc_html
 Now we can transfer our HTML files to our local computer using `scp`, which will look something like this:
 
 ```
-scp username@ipaddress:~/quality/*.html ~/Desktop/fastqc_html
+scp username@ipaddress:~/quality/*.html ~/Desktop/fastqc_html/
 ```
 
 The first part of the command is the address for your remote 


### PR DESCRIPTION
We have two html files and this command is writing to a file instead of folder

PR author:
- [ ] pull request is ready for review & merge

Things to check:

- [ ] tutorial resets working directory at beginning with a `cd ~/``
- [ ] tutorial contains relevant `conda install -y` commands at the beginning
- [ ] tutorial links to previous tutorial (at top) and next tutorial (at bottom)
- [ ] tutorial has learning objectives at top


