### PR TITLE
fix install instructions and remove old output

### DIFF
--- a/snakemake_for_automation.md
+++ b/snakemake_for_automation.md
@@ -26,7 +26,7 @@ cd ~
 Install `snakemake` using conda. 
 
 ```
-conda install -y -c bioconda snakemake-minimal
+conda install -y -c conda-forge -c bioconda snakemake-minimal
 ```
 
 Type the following in your terminal to display a link to Rstudio web-server 
@@ -296,7 +296,6 @@ rule multiqc_raw:
 And it worked! Now we see output like this:
 
 ```
-The flag 'directory' used in rule all is only valid for outputs, not inputs.
 Building DAG of jobs...
 Using shell: /bin/bash
 Provided cores: 1


### PR DESCRIPTION
- At this point channels are probably set up, but since `-c bioconda` is there it's better to be explicit and add `-c conda-forge` too
- also remove and old warning message ('directory' is not being used in the current Snakefile)

PR author:
- [x] pull request is ready for review & merge

Things to check:

- [ ] tutorial resets working directory at beginning with a `cd ~/``
- [ ] tutorial contains relevant `conda install -y` commands at the beginning
- [ ] tutorial links to previous tutorial (at top) and next tutorial (at bottom)
- [ ] tutorial has learning objectives at top

cc @taylorreiter 