### PR TITLE
Fix shell command to use correct dir name

### DIFF
--- a/snakemake_for_automation.md
+++ b/snakemake_for_automation.md
@@ -166,7 +166,7 @@ rule fastqc_raw:
         "fastqc_raw/ERR458493_fastqc.html",
         "fastqc_raw/ERR458493_fastqc.zip"
     shell:'''
-    fastqc -o data {input}
+    fastqc -o fastqc_raw {input}
     '''
 ```
 


### PR DESCRIPTION
This fixes one more instance of the inconsistent dir name

@rociotmartinez can I get another review? Tnx!